### PR TITLE
Rd saucelabs cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 junitxml
 python-subunit
-selenium==3.4.3
+selenium==3.141.0
 Appium-Python-Client==0.24
 testtools==1.8.0
 browsermob-proxy==0.7.1
-sauceclient==0.2.1
+sauceclient==1.0.0
 pytz==2013.7
 enum34==1.1.6

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -130,8 +130,13 @@ class RemoteBrowserFactory(BrowserFactory):
         logger.debug('Remote capabilities set: {}'.format(self.capabilities))
 
     def browser(self):
-        return self.webdriver_class(self.remote_url, self.capabilities)
-
+        try:
+            return self.webdriver_class(self.remote_url, self.capabilities)
+        except:
+            self.remote_client.stop(self.remote_client.get_last_job())
+            raise selenium_exceptions.WebDriverException(
+                'The remote browser could not be started.'
+                'Check https://status.saucelabs.com/')
 
 # MISSINGTEST: Exercise this class -- vila 2013-04-11
 class ChromeFactory(BrowserFactory):

--- a/src/sst/remote_capabilities.py
+++ b/src/sst/remote_capabilities.py
@@ -43,3 +43,11 @@ class SauceLabs(object):
                                                                     name))
         self.client.jobs.update_job(job_id=session_id, name=name,
                                     passed=result)
+    def stop(self, session_id):
+        logger.debug('Stopping job: {}'.format(session_id))
+        self.client.jobs.stop_job(session_id)
+
+    def get_last_job(self):
+        session_id = self.client.jobs.get_jobs()[0]['id']
+        logger.debug('Most recent job id: {}'.format(session_id))
+        return session_id


### PR DESCRIPTION
There's an issue with saucelabs launching browsers, and we are not cleaning up properly in this case. Adding some exception handling for remote browser startup to attempt to retrieve the last job id and kill it when browser startup fails.

@DramaFever/qa 