### PR TITLE
Log API test results to existing test plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ nosetests.xml
 pep8.log
 
 # sst
-config.py
 results
 src/sst.egg-info
 sst-deps
@@ -68,3 +67,6 @@ sst.wpr
 sst.wpu
 src/testproject/testproj.db
 .tox
+
+.DS_Store
+.tags*

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -109,13 +109,26 @@ class RemoteBrowserFactory(BrowserFactory):
             self.remote_url = remote_url
 
     def setup_for_test(self, test):
-        self.capabilities = test.context
 
         if self.webdriver_class == webdriver.Remote:
+            self.capabilities = {
+                'platform': test.context['platform'],
+                'browserName': test.context['browserName'],
+                'version': test.context['version'],
+                'screenResolution': test.context['screenResolution'],
+                'extendedDebugging': True,
+                'idleTimeout': 300}
+            if 'chromeOptions' in test.context:
+                self.capabilities.update({
+                    'chromeOptions': test.context['chromeOptions']})
+            elif 'moz:firefoxOptions' in test.context:
+                self.capabilities.update({
+                    'moz:firefoxOptions': test.context['moz:firefoxOptions']})
             self.capabilities['extendedDebugging'] = True
             self.capabilities['idleTimeout'] = 300
 
         elif self.webdriver_class == appium.webdriver.Remote:
+            self.capabilities = test.context
             self.capabilities['testobject_test_name'] = test.id()
     
         logger.debug('Remote capabilities set: {}'.format(self.capabilities))

--- a/src/sst/cases.py
+++ b/src/sst/cases.py
@@ -186,6 +186,9 @@ class SSTTestCase(testtools.TestCase):
                        testtools.content.text_content(page_source))
 
     def post_api_test_result(self):
+        if not self.run_id:
+            logger.debug("No run id found, skipping sending TestRail results")
+            return None
         logger.debug("Entered send result, run id is {}".format(self.run_id))
         try:
             result = self._get_case_result()

--- a/src/sst/command.py
+++ b/src/sst/command.py
@@ -55,6 +55,14 @@ def reset_directory(path):
             raise
     os.makedirs(path)
 
+def add_plan_id(option, opt_str, value, parser, arg_type, default_arg):
+    try:
+        next_arg = arg_type(parser.rargs[0])
+    except Exception:
+        next_arg = default_arg
+    else:
+        parser.rargs.pop(0)
+    setattr(parser.values, option.dest, next_arg)
 
 def get_common_options():
     parser = optparse.OptionParser(usage=usage)
@@ -106,9 +114,13 @@ def get_common_options():
     parser.add_option('-o', dest='results_directory',
                       default=None,
                       help='directory to output results to')
-    parser.add_option('-t', dest='api_test_results', action='store_true',
-                      default=False,
-                      help='select whether to send API test results')
+    parser.add_option('-t', dest='api_test_results',
+                      default=False, action='callback', nargs=0, type=int,
+                      callback=add_plan_id, callback_args=(int, True),
+                      help='select whether to send API test results.'
+                      ' Optionally takes a plan ID argument to log results to'
+                      ' an existing plan instead of defaulting to creating a'
+                      ' new plan')
     parser.add_option('--proxy', dest='use_proxy',
                       action='store_true', default=False,
                       help='enables BrowserMob proxy and stores HTTP archive'

--- a/src/sst/loaders.py
+++ b/src/sst/loaders.py
@@ -109,6 +109,7 @@ class TestLoader(unittest.TestLoader):
     def discoverTestsFromTree(self, dir_path, package=None):
         suite = self.suiteClass()
         names = os.listdir(dir_path)
+        names = [n for n in names if n != 'appium_config.py']
         if package is None:
             if os.path.isfile(os.path.join(dir_path, '__init__.py')):
                 package = self.importFromPath(dir_path)

--- a/src/sst/loaders.py
+++ b/src/sst/loaders.py
@@ -109,7 +109,7 @@ class TestLoader(unittest.TestLoader):
     def discoverTestsFromTree(self, dir_path, package=None):
         suite = self.suiteClass()
         names = os.listdir(dir_path)
-        names = [n for n in names if n != 'appium_config.py']
+        names = [n for n in names if 'appium_config.py' not in n]
         if package is None:
             if os.path.isfile(os.path.join(dir_path, '__init__.py')):
                 package = self.importFromPath(dir_path)

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -244,6 +244,9 @@ def find_client_credentials(module):
         mod_path = os.path.join(cwd, '{}.py'.format(module))
         if not os.path.isfile(mod_path):
             mod_path = os.path.join(os.path.dirname(cwd), '{}.py'.format(module))
+        if not os.path.isfile(mod_path):
+            mod_path = os.path.join(os.path.abspath(os.path.join(
+                cwd, "../..")), '{}.py'.format(module))
         return imp.load_source(module, os.path.abspath(mod_path))
 
 def set_client_credentials(client):

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -128,7 +128,8 @@ def runtests(test_regexps, results_directory, out,
                 runs_list = client.get_runs_in_plan(plan_id)
                 existing_runs = []
                 for browser in browser_factory.browsers:
-                    platform_string = "{} {}, {}".format(browser['browserName'],
+                    platform_string = "{} {}, {}".format(
+                        browser['browserName'].lower(),
                         browser['version'].split('.')[0],
                         browser['platform'].lower())
                     run_found = False

--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -99,22 +99,24 @@ def runtests(test_regexps, results_directory, out,
                 for browser in browser_factory.browsers:
                     tests = [t.case_id for t in alltests._tests if t.case_id]
                     ids = list(OrderedDict.fromkeys(tests))
-                    try:
-                        browser_name = 'browserName'
-                        platform_string = '{} - {} - {}'.format(
-                                           browser['platform'],
-                                           browser[browser_name],
-                                           browser['version'])
-                    except KeyError:
-                        browser_name = 'deviceName'
-                        platform_string = '{} - {}'.format(
-                                           browser[browser_name],
-                                           browser['platformVersion'])
-
+                    # web
+                    if 'browserName' in browser.keys():
+                        platform = 'platform'
+                        version = 'version'
+                        name = 'browserName'
+                    # app
+                    else:
+                        platform = 'platformName'
+                        version = 'platformVersion'
+                        name = 'deviceName'
+                    platform_string = '{} - {} - {}'.format(
+                        browser[platform],
+                        browser[name],
+                        browser[version])
                     test_run = client.create_test_run(ids, platform_string)
                     logger.debug('Cases in current run ({} {}:{}): {}'.format(
-                                  browser[browser_name],
-                                  browser['version'],
+                                  browser[name],
+                                  browser[version],
                                   test_run['run_id'],
                                   ids))
                     for test in alltests._tests:
@@ -128,10 +130,20 @@ def runtests(test_regexps, results_directory, out,
                 runs_list = client.get_runs_in_plan(plan_id)
                 existing_runs = []
                 for browser in browser_factory.browsers:
-                    platform_string = "{} {}, {}".format(
-                        browser['browserName'].lower(),
-                        browser['version'].split('.')[0],
-                        browser['platform'].lower())
+                    # web
+                    if 'browserName' in browser.keys():
+                        platform = 'platform'
+                        version = 'version'
+                        name = 'browserName'
+                    # app
+                    else:
+                        platform = 'platformName'
+                        version = 'platformVersion'
+                        name = 'deviceName'
+                    platform_string = '{} {}, {}'.format(
+                        browser[name].lower(),
+                        browser[version].split('.')[0],
+                        browser[platform].lower())
                     run_found = False
                     for test_run in runs_list:
                         if test_run['config']:
@@ -150,10 +162,20 @@ def runtests(test_regexps, results_directory, out,
                 # add run_id to individual tests
                 for test_run in existing_runs:
                     for test in alltests._tests:
-                        test_context = "{} {}, {}".format(
-                            test.context['browserName'].lower(),
-                            test.context['version'].split('.')[0],
-                            test.context['platform'].lower())
+                        # web
+                        if 'browserName' in test.context.keys():
+                            platform = 'platform'
+                            version = 'version'
+                            name = 'browserName'
+                        # app
+                        else:
+                            platform = 'platformName'
+                            version = 'platformVersion'
+                            name = 'deviceName'
+                        test_context = '{} {}, {}'.format(
+                            test.context[name].lower(),
+                            test.context[version].split('.')[0],
+                            test.context[platform].lower())
                         if test_run['config']:
                             run_config = test_run['config'].lower()
                         else:

--- a/src/sst/testrail_helper.py
+++ b/src/sst/testrail_helper.py
@@ -47,6 +47,7 @@ class TestRailHelper(object):
                 }
             )
             self.plan_id = plan['id']
+            return plan
         except Exception as e:
             logger.debug("Could not create TestRail test plan \n" + str(e))
 
@@ -80,6 +81,18 @@ class TestRailHelper(object):
                 return run_data
             except Exception as e:
                 logger.debug("Could not create TestRail test run \n" + str(e))
+
+    def _get_entry_id(self, run_id):
+        endpoint = 'get_run/{}'.format(run_id)
+        run = self.client.send_get(endpoint)
+
+    def update_test_run(self, plan_id, entry_id, field, value):
+        endpoint = 'update_plan_entry/{}/{}'.format(plan_id, entry_id)
+        payload = {''.format(field) : ''.format(value)}
+        try:
+            self.client.send_post(endpoint, payload)
+        except Exception as e:
+            logger.debug("Could not update TestRail test run \n" + str(e))
 
     # add test case results to test run
     def send_results(self):

--- a/src/sst/testrail_helper.py
+++ b/src/sst/testrail_helper.py
@@ -29,10 +29,11 @@ class TestRailHelper(object):
 
     def get_runs_in_plan(self, plan_id):
         plan = self.get_plan(plan_id)
-        runs_list = []
         try:
+            runs_list = []
             for entry in plan['entries']:
-                runs_list.append(entry['runs'][0])
+                for run in entry['runs']:
+                    runs_list.append(run)
             return runs_list
         except Exception as e:
             logger.debug("Could not find test runs \n" + str(e))
@@ -99,6 +100,9 @@ class TestRailHelper(object):
             "comment": comment
         }
         self.store_json_results(result, case_id)
+        if not run_id:
+            logger.debug("Run ID does not exist")
+            return None
         try:
             run = self.client.send_post('add_result_for_case/{}/{}'
                                         .format(run_id, case_id), result)

--- a/src/sst/testrail_helper.py
+++ b/src/sst/testrail_helper.py
@@ -24,6 +24,19 @@ class TestRailHelper(object):
     def _get_suite(self):
         return self.client.send_get('get_suites/{}'.format(self.project_id))
 
+    def get_plan(self, plan_id):
+        return self.client.send_get('get_plan/{}'.format(plan_id))
+
+    def get_runs_in_plan(self, plan_id):
+        plan = self.get_plan(plan_id)
+        runs_list = []
+        try:
+            for entry in plan['entries']:
+                runs_list.append(entry['runs'][0])
+            return runs_list
+        except Exception as e:
+            logger.debug("Could not find test runs \n" + str(e))
+
     def create_test_plan(self):
         time = self._get_time()
         try:


### PR DESCRIPTION
This is meant to extend our current support of creating a new test plan or run for which to log our test results to an external test case management system, in this case TestRail, by allowing an optional argument with the `-t` flag to specify an existing test plan ID.

Instead of isolating our automated test suite results into separate test plans, this will allow us to have our automated results logged to a greater test plan of manual cases to better see the percentage of manual vs automated cases for a given plan without having to manually copy over any results.