### PR TITLE
Fix frequency of logging for how many TestRail runs are created

### DIFF
--- a/src/sst/runtests.py
+++ b/src/sst/runtests.py
@@ -122,8 +122,8 @@ def runtests(test_regexps, results_directory, out,
                     for test in alltests._tests:
                         if browser == test.context:
                             test.run_id = test_run['run_id']
-                    logger.debug('Created test runs {} using the above cases'
-                                 .format(client.runs))
+                logger.debug('Created test runs {} using the above cases'
+                                .format(client.runs))
 
             elif type(config.api_test_results) == int:
                 plan_id = config.api_test_results


### PR DESCRIPTION
This was causing the list of test runs to get printed out for each browser. Instead, move out a level and only log the full list once, after the full list of TestRail browser runs has been created.