### PR TITLE
Refactor get_text to support Safari browser

### DIFF
--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -46,6 +46,8 @@ import os
 import re
 import time
 
+import selenium.webdriver.safari.webdriver
+
 from datetime import datetime
 from functools import wraps
 from pdb import set_trace as debug
@@ -449,7 +451,10 @@ def get_text(id_or_elem):
 
     """
     element = _get_elem(id_or_elem)
-    return element.text
+    if isinstance(_test.browser, selenium.webdriver.safari.webdriver.WebDriver):
+        return element.text.strip()
+    else:
+        return element.text
 
 
 def toggle_checkbox(id_or_elem):

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -46,8 +46,6 @@ import os
 import re
 import time
 
-import selenium.webdriver.safari.webdriver
-
 from datetime import datetime
 from functools import wraps
 from pdb import set_trace as debug
@@ -452,9 +450,7 @@ def get_text(id_or_elem):
     """
     element = _get_elem(id_or_elem)
     try:
-        if (isinstance(_test.browser,
-                selenium.webdriver.safari.webdriver.WebDriver) or
-                _test.browser.capabilities['browserName'].lower() == 'safari'):
+        if _test.browser.capabilities['browserName'].lower() == 'safari':
             return element.text.strip()
     except:
         logger.debug('Cound not verify Safari browser for get_text.')

--- a/src/sst/actions.py
+++ b/src/sst/actions.py
@@ -451,10 +451,14 @@ def get_text(id_or_elem):
 
     """
     element = _get_elem(id_or_elem)
-    if isinstance(_test.browser, selenium.webdriver.safari.webdriver.WebDriver):
-        return element.text.strip()
-    else:
-        return element.text
+    try:
+        if (isinstance(_test.browser,
+                selenium.webdriver.safari.webdriver.WebDriver) or
+                _test.browser.capabilities['browserName'].lower() == 'safari'):
+            return element.text.strip()
+    except:
+        logger.debug('Cound not verify Safari browser for get_text.')
+    return element.text
 
 
 def toggle_checkbox(id_or_elem):


### PR DESCRIPTION
When running tests in Safari, using selenium `.text` on an element does not strip out the whitespace characters, e.g.

```
'\n          testing\n        '
```
this will call `.strip()` on the string in get_text if the browser is Safari