### PR TITLE
Support mobile web Appium tests on Sauce Labs

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -135,8 +135,7 @@ class RemoteBrowserFactory(BrowserFactory):
             self.capabilities = {
                 'platformName': test.context['platformName'],
                 'deviceName': test.context['deviceName'],
-                'platformVersion': test.context['platformVersion'],
-                'browserName': test.context['browserName']
+                'platformVersion': test.context['platformVersion']
             }
             if not 'browserName' in test.context:
                 self.capabilities.update(

--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -82,11 +82,17 @@ class RemoteBrowserFactory(BrowserFactory):
             self.creds = runtests.set_client_credentials('saucelabs')
             try:
                 if 'CAPABILITIES' in dir(self.creds):
-                    self.browsers = self.creds.CAPABILITIES
-                    self.remote_url = self.creds.APPIUM_URL
+                    # mobile device
                     self.webdriver_class = appium.webdriver.Remote
-                    apibase = self.creds.API_BASE
-                else:
+                    self.browsers = self.creds.CAPABILITIES
+                    if 'browserName' not in self.creds.CAPABILITIES[0].keys():
+                        # test object
+                        self.remote_url = self.creds.APPIUM_URL
+                        apibase = self.creds.API_BASE
+                    else: # mobile web emulator
+                        self.remote_url = self.creds.URL
+                        apibase = None
+                else: # desktop web vm
                     self.browsers = self.creds.BROWSERS
                     self.remote_url = self.creds.URL
                     apibase = None
@@ -130,12 +136,21 @@ class RemoteBrowserFactory(BrowserFactory):
                 'platformName': test.context['platformName'],
                 'deviceName': test.context['deviceName'],
                 'platformVersion': test.context['platformVersion'],
-                'testobject_api_key': test.context['testobject_api_key'],
-                'testobject_suite_name': test.context['testobject_suite_name'],
-                'testobject_report_results': test.context['testobject_report_results']
-                }
-            self.capabilities['testobject_test_name'] = test.id()
+                'browserName': test.context['browserName']
+            }
+            if not 'browserName' in test.context:
+                self.capabilities.update(
+                    {
+                    'testobject_api_key': test.context['testobject_api_key'],
+                    'testobject_suite_name': test.context['testobject_suite_name'],
+                    'testobject_report_results': test.context['testobject_report_results']
+                    }
+                )
+                self.capabilities['testobject_test_name'] = test.id()
             self.capabilities['extendedDebugging'] = True
+            if 'browserName' in test.context:
+                self.capabilities.update(
+                    {'browserName': test.context['browserName']})
             if 'phoneOnly' in test.context:
                 self.capabilities.update(
                     {'phoneOnly': test.context['phoneOnly']})


### PR DESCRIPTION
This lets us create a sauce labs configuration file for mobile web and specify a device and browser to run tests via Appium, instead of defaulting to all Appium tests being for native apps and requiring the Test Object app info.

@babybunnytoto Can you please make sure that with this change, everything with the native app testing still works as expected?

FYI @louisekent 