### PR TITLE
Set the appiumVersion capability from test context

### DIFF
--- a/src/sst/browsers.py
+++ b/src/sst/browsers.py
@@ -159,6 +159,9 @@ class RemoteBrowserFactory(BrowserFactory):
             if 'newCommandTimeout' in test.context:
                 self.capabilities.update(
                     {'newCommandTimeout': test.context['newCommandTimeout']})
+            if 'appiumVersion' in test.context:
+                self.capabilities.update(
+                    {'appiumVersion': test.context['appiumVersion']})
         logger.debug('Remote capabilities set: {}'.format(self.capabilities))
 
     def browser(self):


### PR DESCRIPTION
Add the ability to set the `appiumVersion` as a capability if it is present in the test context